### PR TITLE
LAB-24: Build ‘fetch and dump’ code in local machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.log
+*.html
+*.json
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.8-slim-buster
+
+WORKDIR /app
+
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
+
+COPY . .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+beautifulsoup4==4.10.0
+requests==2.27.1
+unicode_slugify==0.1.5

--- a/web_scrapper.py
+++ b/web_scrapper.py
@@ -1,0 +1,48 @@
+import requests
+from bs4 import BeautifulSoup
+import json
+
+
+def remove_html_tags(text):
+    """Remove html tags from a string"""
+    import re
+    clean = re.compile('<.*?>')
+    return re.sub(clean, '', text)
+
+
+listing_html = requests.get(
+    "https://www.linkedin.com/jobs/software-engineer-intern-jobs-united-states/")
+
+doc = BeautifulSoup(listing_html.text, "html.parser")
+
+
+jobs_ul = doc.find("ul", {"class": "jobs-search__results-list"})
+
+data_dump = {}
+for li in jobs_ul.find_all("li"):
+    try:
+        posting_url = li.div.a['href']
+        posting_url = posting_url.split("?", 1)[0]
+        temp_dict = {}
+        posting_html = requests.get(
+            posting_url)
+        listing = BeautifulSoup(posting_html.text, "html.parser")
+        job_title = listing.find(
+            "h1", {"class": "top-card-layout__title topcard__title"}).string
+        temp_dict['job_title'] = job_title.strip()
+        company_name = listing.find(
+            "a", {"class": "topcard__org-name-link"}).string
+        temp_dict['company_name'] = company_name.strip()
+        location = listing.find(
+            "span", {"class": "topcard__flavor topcard__flavor--bullet"}).string
+        temp_dict['location'] = location.strip()
+        description = listing.find(
+            "div", {"class": "description__text"}).find("div", {"class": "show-more-less-html__markup"})
+        temp_dict['description'] = remove_html_tags(str(description)).strip()
+        data_dump[posting_url] = temp_dict
+    except Exception:
+        with open('error.txt', 'w') as file:
+            file.write(posting_url)
+
+with open('result.json', 'w') as file:
+    json.dump(data_dump, file, indent=4)


### PR DESCRIPTION
The web scrapper is a POC to fetch job posting from LinkedIn and create a local dump. 
## JIRA: 
Link : [LAB-24](https://oregonstate-innovationlab.atlassian.net/browse/LAB-24) 
## Features:
- Gets job listing for role 'Software Engineer Intern' in location 'United States'.
- Retrieves details of each listing and writes it into a local file 'result.json'.
- If there is an error while retrieving details of some listing, the 'url' is written into a local file 'error.txt'.


## What is not handled:
- The job listing page has an infinite scroll. The current implementation only retrieves the initial listings on the page.
- Remove hardcoding of role and location 

## How to review:
- Clone the repository: `git clone git@github.com:RN35/job-market-trends.git`
- Change dir: `cd job-market-trends`
- Checkout branch feat/LAB-24: `git checkout feat/LAB-24`
- Run Docker Desktop
- Build docker container: `docker build . -t job-market-trends-web-scrapper`
- Run docker container: `docker run --interactive --tty --entrypoint /bin/sh job-market-trends-web-scrapper`
- Run command: `python3 web_scrapper.py`
- Validate by checking results in 'result.json' and check logs using '*.log'
- Exit docker container and delete image: `docker image rm -f job-market-trends-web-scrapper`

## Screenshots

### Sample result

<img width="1067" alt="image" src="https://user-images.githubusercontent.com/15828512/155253545-5583301a-f9fb-4cd2-86bd-871e2dc9408a.png">


### Traceback in the log file
<img width="1241" alt="image" src="https://user-images.githubusercontent.com/15828512/155253375-af40bf2d-be9a-47ba-afb6-c26f33c1f7bb.png">
